### PR TITLE
Modular captions and API upgrade

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,16 @@
 GATEWAY_PORT=7005
 # CORS_ORIGINS=http://localhost:5173
 
-# Captioning (Gemma 4 via llama-server)
+# Captioning (local Gemma 4 via llama-server)
 CAPTIONING_ENABLED=true
 CAPTIONING_MODEL=/models/vision.gguf
 CAPTIONING_MMPROJ=/models/vision.mmproj.gguf
 CAPTIONING_CTX_SIZE=8192
 CAPTIONING_N_PREDICT=1024
+
+# Captioning (API mode — use instead of local model)
+# Set CAPTIONING_ENDPOINT to use an external API. The local captioning
+# container will not start when an endpoint is configured.
+# CAPTIONING_ENDPOINT=https://api.openai.com/v1/chat/completions
+# CAPTIONING_API_KEY=sk-...
+# CAPTIONING_API_MODEL=gpt-4o

--- a/README.md
+++ b/README.md
@@ -2,26 +2,28 @@
 
 # Canonizr
 
-On-device document extraction pipeline. Converts any document into LLM-ready markdown.
+Document extraction pipeline. Converts any document into LLM-ready markdown.
 Canonizr is part of the [Health Data Avatar](healthdataavatar.com) project, and there are more details available at [Canonizr.com](Canonizr.com).
+
+The entire pipeline can be run on-device, or you can pass certain jobs to external APIs.
 
 ## Quick Start
 
 ```bash
 git clone <repo-url> && cd canonizr-pipelines
 ./bin/setup.sh
-docker compose up
+canonizr up
 ```
 
 Then convert a document:
 
 ```bash
-./cli/canonizr convert document.pdf
+canonizr convert document.pdf    # creates document.pdf.md
 ```
 
 ## What it does
 
-Send any file in, get markdown out. PDFs with complex layouts, scanned documents, images, office files — all handled locally, no data leaves your machine.
+Send any file in, get markdown out. PDFs with complex layouts, scanned documents, images, office files. Runs locally by default — optionally use an external API for image captioning.
 
 See [filetypes.md](filetypes.md) for the full list of supported formats.
 
@@ -30,9 +32,14 @@ See [filetypes.md](filetypes.md) for the full list of supported formats.
 If you have run `./bin/setup.sh` then `canonizr` will be added to your PATH.
 
 ```bash
-canonizr convert <file>          # markdown to stdout
-canonizr convert --json <file>   # full JSON response with metadata
-canonizr health                  # check if the service is running
+canonizr convert <file>           # writes <file>.md, job JSON to stdout
+canonizr convert <file> -o -      # markdown to stdout (for piping)
+canonizr convert <file> -o a.md   # custom output path
+canonizr convert <file> -f        # overwrite existing output
+canonizr convert <file> -q        # quiet, no job JSON
+canonizr up [--fg]                # start the pipeline (--fg for logs)
+canonizr down                     # stop the pipeline
+canonizr health                   # check if the service is running
 ```
 
 ## Web UI
@@ -55,8 +62,8 @@ Then open http://localhost:5173.
 |---|---|
 | `./bin/setup.sh` | One-time configuration (writes `.env`) |
 | `./bin/setup.sh --no-captioning` | Setup without the captioning VLM (~6 GB smaller) |
-| `./bin/up.sh` | Start the pipeline |
-| `./bin/down.sh` | Stop the pipeline |
+| `./bin/up.sh` | Start the pipeline (delegates to `canonizr up`) |
+| `./bin/down.sh` | Stop the pipeline (delegates to `canonizr down`) |
 
 ## Requirements
 
@@ -67,13 +74,34 @@ Then open http://localhost:5173.
 
 All configuration lives in `.env`. Copy from `.env.example` or run `./bin/setup.sh`.
 
+### Captioning
+
+Image captioning can run locally or via an external API:
+
+| Mode | Config | Container needed? |
+|---|---|---|
+| **Off** | `CAPTIONING_ENABLED=false` | No |
+| **Local** (default) | `CAPTIONING_ENABLED=true` | Yes — llama.cpp + Gemma 4 (~6 GB) |
+| **API** | `CAPTIONING_ENABLED=true` + `CAPTIONING_ENDPOINT` + `CAPTIONING_API_KEY` | No |
+
+For API mode, set these in `.env`:
+
+```env
+CAPTIONING_ENABLED=true
+CAPTIONING_ENDPOINT=https://api.openai.com/v1/chat/completions  # must end with /chat/completions
+CAPTIONING_API_KEY=sk-...
+CAPTIONING_API_MODEL=gpt-4o
+```
+
+Any OpenAI-compatible endpoint works (OpenAI, Azure OpenAI, Nebius, etc.).
+
 ## Architecture
 
 | Service | Role |
 |---|---|
 | **Gateway** | Format detection, routing, MarkItDown, pymupdf, Pillow |
 | **Docling** | PDF layout analysis, table extraction, figure classification |
-| **Captioning** | On-device VLM (Gemma 4) for images, figures, scanned pages |
+| **Captioning** | VLM for images, figures, scanned pages (local Gemma 4 or external API) |
 | **LibreOffice** | Legacy format conversion (DOC, PPT, XLS, Apple formats) |
 
 Only the gateway port is exposed. All services communicate internally over the Docker network.

--- a/bin/down.sh
+++ b/bin/down.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-docker compose down

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -60,45 +60,65 @@ if [[ "$enable_captioning" =~ ^[Nn]$ ]]; then
 else
   CAPTIONING_ENABLED="true"
 
-  DEFAULT_MODEL="/models/vision.gguf"
-  DEFAULT_MMPROJ="/models/vision.mmproj.gguf"
+  echo ""
+  echo "Captioning mode:"
+  echo "  1) Local — Gemma 4 via llama.cpp (~6 GB download)"
+  echo "  2) API  — Nebius, OpenAI, or compatible endpoint"
+  read -rp "Choose [1]: " captioning_mode
+  captioning_mode="${captioning_mode:-1}"
 
-  MODEL_URL="https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf"
-  MMPROJ_URL="https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/mmproj-F16.gguf"
-
-  # Check if model files exist locally, offer to download if missing
-  mkdir -p ./models
-
-  if [ ! -f "./models/vision.gguf" ]; then
+  if [ "$captioning_mode" = "2" ]; then
+    # API mode
     echo ""
-    echo "Model file not found: ./models/vision.gguf (4.98 GB)"
-    read -rp "Download it now? (Y/n) " dl_model
-    if [[ ! "$dl_model" =~ ^[Nn]$ ]]; then
-      echo "Downloading vision model..."
-      curl -L -o ./models/vision.gguf "$MODEL_URL"
-    else
-      echo "Download it manually:"
-      echo "  curl -L -o ./models/vision.gguf $MODEL_URL"
-    fi
-  fi
+    read -rp "Endpoint URL: " captioning_endpoint
+    read -rp "API key: " captioning_api_key
+    read -rp "Model name (e.g. gpt-4o): " captioning_api_model
 
-  if [ ! -f "./models/vision.mmproj.gguf" ]; then
-    echo ""
-    echo "Vision projector not found: ./models/vision.mmproj.gguf (990 MB)"
-    read -rp "Download it now? (Y/n) " dl_mmproj
-    if [[ ! "$dl_mmproj" =~ ^[Nn]$ ]]; then
-      echo "Downloading vision projector..."
-      curl -L -o ./models/vision.mmproj.gguf "$MMPROJ_URL"
-    else
-      echo "Download it manually:"
-      echo "  curl -L -o ./models/vision.mmproj.gguf $MMPROJ_URL"
-    fi
-  fi
+    CAPTIONING_VARS="CAPTIONING_ENDPOINT=$captioning_endpoint
+CAPTIONING_API_KEY=$captioning_api_key
+CAPTIONING_API_MODEL=$captioning_api_model"
+  else
+    # Local mode
+    DEFAULT_MODEL="/models/vision.gguf"
+    DEFAULT_MMPROJ="/models/vision.mmproj.gguf"
 
-  CAPTIONING_VARS="CAPTIONING_MODEL=$DEFAULT_MODEL
+    MODEL_URL="https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf"
+    MMPROJ_URL="https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/mmproj-F16.gguf"
+
+    # Check if model files exist locally, offer to download if missing
+    mkdir -p ./models
+
+    if [ ! -f "./models/vision.gguf" ]; then
+      echo ""
+      echo "Model file not found: ./models/vision.gguf (4.98 GB)"
+      read -rp "Download it now? (Y/n) " dl_model
+      if [[ ! "$dl_model" =~ ^[Nn]$ ]]; then
+        echo "Downloading vision model..."
+        curl -L -o ./models/vision.gguf "$MODEL_URL"
+      else
+        echo "Download it manually:"
+        echo "  curl -L -o ./models/vision.gguf $MODEL_URL"
+      fi
+    fi
+
+    if [ ! -f "./models/vision.mmproj.gguf" ]; then
+      echo ""
+      echo "Vision projector not found: ./models/vision.mmproj.gguf (990 MB)"
+      read -rp "Download it now? (Y/n) " dl_mmproj
+      if [[ ! "$dl_mmproj" =~ ^[Nn]$ ]]; then
+        echo "Downloading vision projector..."
+        curl -L -o ./models/vision.mmproj.gguf "$MMPROJ_URL"
+      else
+        echo "Download it manually:"
+        echo "  curl -L -o ./models/vision.mmproj.gguf $MMPROJ_URL"
+      fi
+    fi
+
+    CAPTIONING_VARS="CAPTIONING_MODEL=$DEFAULT_MODEL
 CAPTIONING_MMPROJ=$DEFAULT_MMPROJ
 CAPTIONING_CTX_SIZE=8192
 CAPTIONING_N_PREDICT=1024"
+  fi
 fi
 
 # Gateway port

--- a/bin/up.sh
+++ b/bin/up.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-source .env 2>/dev/null || true
-if [ "${CAPTIONING_ENABLED:-true}" = "false" ]; then
-  docker compose up --build gateway docling libreoffice
-else
-  docker compose up --build
-fi

--- a/cli/canonizr
+++ b/cli/canonizr
@@ -10,23 +10,31 @@ usage() {
   echo "Usage: canonizr <command>"
   echo ""
   echo "Commands:"
-  echo "  up        Start the pipeline"
+  echo "  up [--fg] Start the pipeline (--fg for foreground with logs)"
   echo "  down      Stop the pipeline"
   echo "  convert   Convert a file to markdown"
   echo "  health    Check if the service is running"
   echo ""
   echo "Options:"
-  echo "  convert [--json] <file>"
+  echo "  convert [-o <file>] [-f] [-q] <file>"
+  echo "    -o <file>   Output path (default: <input>.md)"
+  echo "    -o -        Write markdown to stdout instead of file"
+  echo "    -f          Overwrite output file if it exists"
+  echo "    -q          Quiet mode, suppress job summary"
   exit 1
 }
 
 cmd_convert() {
-  local json_mode=false
+  local force=false
+  local quiet=false
+  local output=""
   local file=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --json) json_mode=true; shift ;;
+      -f|--force) force=true; shift ;;
+      -q|--quiet) quiet=true; shift ;;
+      -o) shift; output="$1"; shift ;;
       *) file="$1"; shift ;;
     esac
   done
@@ -40,16 +48,60 @@ cmd_convert() {
     exit 1
   fi
 
-  response=$(curl -sf "${BASE_URL}/convert" -F "file=@${file}" 2>&1) || {
-    echo "Error: could not reach Canonizr at ${BASE_URL}" >&2
-    echo "Is the service running? Start it with: canonizr up" >&2
-    exit 1
-  }
+  # Skip files that are already plaintext/markdown
+  case "${file##*.}" in
+    md|markdown|txt|csv|json|xml|html|py|java|c|h)
+      echo "${file} is already a text format, skipping" >&2
+      exit 0
+      ;;
+  esac
 
-  if [[ "$json_mode" == "true" ]]; then
-    echo "$response"
+  # Default output: <input>.md (e.g. report.pdf -> report.pdf.md)
+  if [[ -z "$output" ]]; then
+    output="${file}.md"
+  fi
+
+  # Check for existing output (unless writing to stdout or force)
+  if [[ "$output" != "-" ]] && [[ "$force" != "true" ]] && [[ -f "$output" ]]; then
+    echo "${output} already exists, skipping (use -f to overwrite)" >&2
+    exit 0
+  fi
+
+  # Request markdown body with metadata in header
+  local tmpfile
+  tmpfile=$(mktemp)
+  trap 'rm -f "$tmpfile"' RETURN
+
+  local http_code metadata
+  if [[ "$output" == "-" ]]; then
+    # Pipe mode: write markdown to stdout via curl
+    metadata=$(curl -sf -D "$tmpfile" \
+      -H "Accept: text/markdown" \
+      -F "file=@${file}" \
+      "${BASE_URL}/convert" 2>/dev/null) || {
+      echo "Error: could not reach Canonizr at ${BASE_URL}" >&2
+      echo "Is the service running? Start it with: canonizr up" >&2
+      exit 1
+    }
+    # markdown went to stdout already via curl, extract metadata from headers
+    metadata=$(grep -i '^x-job-metadata:' "$tmpfile" | sed 's/^[^:]*: //' | tr -d '\r')
   else
-    echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['markdown'])"
+    # File mode: write markdown directly to output file
+    http_code=$(curl -sf -o "$output" -D "$tmpfile" -w "%{http_code}" \
+      -H "Accept: text/markdown" \
+      -F "file=@${file}" \
+      "${BASE_URL}/convert" 2>/dev/null) || {
+      rm -f "$output"
+      echo "Error: could not reach Canonizr at ${BASE_URL}" >&2
+      echo "Is the service running? Start it with: canonizr up" >&2
+      exit 1
+    }
+    metadata=$(grep -i '^x-job-metadata:' "$tmpfile" | sed 's/^[^:]*: //' | tr -d '\r')
+
+    # Print metadata JSON to stdout
+    if [[ "$quiet" != "true" ]] && [[ -n "$metadata" ]]; then
+      echo "$metadata"
+    fi
   fi
 }
 
@@ -61,18 +113,25 @@ cmd_health() {
 }
 
 cmd_up() {
+  local detach="-d"
+  for arg in "$@"; do
+    case "$arg" in
+      --fg) detach="" ;;
+    esac
+  done
+
   cd "$REPO_ROOT"
   source .env 2>/dev/null || true
-  if [ "${CAPTIONING_ENABLED:-true}" = "false" ]; then
-    docker compose up -d --build gateway docling libreoffice
+  if [ "${CAPTIONING_ENABLED:-true}" = "true" ] && [ -z "${CAPTIONING_ENDPOINT:-}" ]; then
+    docker compose --profile captioning up $detach --build
   else
-    docker compose up -d --build
+    docker compose up $detach --build
   fi
 }
 
 cmd_down() {
   cd "$REPO_ROOT"
-  docker compose down
+  docker compose --profile captioning down
 }
 
 if [[ $# -lt 1 ]]; then
@@ -80,7 +139,7 @@ if [[ $# -lt 1 ]]; then
 fi
 
 case "$1" in
-  up) cmd_up ;;
+  up) shift; cmd_up "$@" ;;
   down) cmd_down ;;
   convert) shift; cmd_convert "$@" ;;
   health) cmd_health ;;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,9 @@ services:
       - "${GATEWAY_PORT:-7005}:8000"
     environment:
       - CAPTIONING_ENABLED=${CAPTIONING_ENABLED:-true}
+      - CAPTIONING_ENDPOINT=${CAPTIONING_ENDPOINT:-}
+      - CAPTIONING_API_KEY=${CAPTIONING_API_KEY:-}
+      - CAPTIONING_API_MODEL=${CAPTIONING_API_MODEL:-}
       - CORS_ORIGINS=${CORS_ORIGINS:-*}
       - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
       - REQUEST_TIMEOUT=${REQUEST_TIMEOUT:-300}
@@ -49,6 +52,7 @@ services:
       start_period: 10s
 
   captioning:
+    profiles: ["captioning"]
     image: ghcr.io/ggml-org/llama.cpp:server
     volumes:
       - ./models:/models

--- a/gateway/app/app.py
+++ b/gateway/app/app.py
@@ -1,8 +1,9 @@
 import asyncio
 import os
 
-from fastapi import FastAPI, File, Query, UploadFile, HTTPException
+from fastapi import FastAPI, File, Header, Query, UploadFile, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import Response
 import magic
 from io import BytesIO
 
@@ -28,6 +29,7 @@ if CORS_ORIGINS:
 async def convert_document(
     file: UploadFile = File(...),
     verbose: bool = Query(False),
+    accept: str = Header("application/json"),
 ):
     """Convert a file to markdown."""
     content = BytesIO()
@@ -58,6 +60,14 @@ async def convert_document(
         try:
             result = await convert(file_bytes, mime_type, file.filename or "document", REQUEST_TIMEOUT, debug)
             result.detected_type = mime_type
+
+            if "text/markdown" in accept:
+                return Response(
+                    content=result.markdown,
+                    media_type="text/markdown; charset=utf-8",
+                    headers={"X-Job-Metadata": result.metadata_json()},
+                )
+
             return result.to_dict(verbose=verbose)
         except UnsupportedFormat as e:
             raise HTTPException(status_code=400, detail=str(e))

--- a/gateway/app/response.py
+++ b/gateway/app/response.py
@@ -1,3 +1,5 @@
+import json
+
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -7,7 +9,8 @@ class ConvertResult:
     markdown: str
     detected_type: str = ""
     actions: list[str] = field(default_factory=list)
-    warnings: list[str] = field(default_factory=list)
+    warnings: list[dict] = field(default_factory=list)
+    completeness: str = "full"
     debug: list[dict] = field(default_factory=list)
     processing_time_ms: float = 0.0
     images_captioned: int = 0
@@ -16,15 +19,23 @@ class ConvertResult:
     def to_dict(self, verbose: bool = False) -> dict[str, Any]:
         result: dict[str, Any] = {
             "markdown": self.markdown,
-            "metadata": {
-                "detected_type": self.detected_type,
-                "processing_time_ms": self.processing_time_ms,
-                "images_captioned": self.images_captioned,
-                "images_skipped": self.images_skipped,
-                "actions": self.actions,
-                "warnings": self.warnings,
-            },
+            "metadata": self._metadata(),
         }
         if verbose and self.debug:
             result["debug"] = self.debug
         return result
+
+    def _metadata(self) -> dict[str, Any]:
+        return {
+            "detected_type": self.detected_type,
+            "completeness": self.completeness,
+            "processing_time_ms": round(self.processing_time_ms),
+            "images_captioned": self.images_captioned,
+            "images_skipped": self.images_skipped,
+            "actions": self.actions,
+            "warnings": self.warnings,
+        }
+
+    def metadata_json(self) -> str:
+        """Compact JSON metadata for use in HTTP headers."""
+        return json.dumps(self._metadata(), separators=(",", ":"))

--- a/gateway/app/services/captioning.py
+++ b/gateway/app/services/captioning.py
@@ -11,16 +11,30 @@ from ..response import ConvertResult
 
 logger = logging.getLogger(__name__)
 
-ENDPOINT = "http://captioning:8080/v1/chat/completions"
+ENDPOINT = os.environ.get(
+    "CAPTIONING_ENDPOINT",
+    "http://captioning:8080/v1/chat/completions",
+)
+API_KEY = os.environ.get("CAPTIONING_API_KEY", "")
+API_MODEL = os.environ.get("CAPTIONING_API_MODEL", "")
 
 
 def is_available() -> bool:
     return os.environ.get("CAPTIONING_ENABLED", "true").lower() == "true"
 
 
+def get_config() -> dict:
+    """Return captioning config safe for inclusion in warnings/logs."""
+    return {
+        "endpoint": ENDPOINT,
+        "api_key": f"set ({len(API_KEY)} chars)" if API_KEY else "not set",
+        "model": API_MODEL or "not set",
+    }
+
+
 async def _call(image_b64: str, mime_type: str, prompt: str, max_tokens: int, timeout: float) -> tuple[dict, float]:
     """Send a base64-encoded image to the captioning service."""
-    payload = {
+    payload: dict = {
         "messages": [
             {
                 "role": "user",
@@ -40,10 +54,16 @@ async def _call(image_b64: str, mime_type: str, prompt: str, max_tokens: int, ti
         ],
         "max_tokens": max_tokens,
     }
+    if API_MODEL:
+        payload["model"] = API_MODEL
+
+    headers = {}
+    if API_KEY:
+        headers["Authorization"] = f"Bearer {API_KEY}"
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         start_time = time.time()
-        response = await client.post(ENDPOINT, json=payload)
+        response = await client.post(ENDPOINT, json=payload, headers=headers)
         elapsed = (time.time() - start_time) * 1000
 
         if response.status_code != 200:

--- a/gateway/app/services/docling.py
+++ b/gateway/app/services/docling.py
@@ -2,6 +2,7 @@ import base64
 import logging
 import re
 import time
+from dataclasses import dataclass
 from enum import Enum
 from io import BytesIO
 
@@ -78,18 +79,27 @@ def _image_dimensions(image_b64: str) -> tuple[int, int]:
     return img.size
 
 
+@dataclass
+class CaptionResult:
+    markdown: str
+    captioned: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+
 async def _caption_images(
     md_content: str, pictures: list[dict], timeout: float, debug: list[dict],
-) -> tuple[str, int, int]:
-    """Replace base64 images in markdown with captions. Returns (markdown, captioned, skipped)."""
+) -> CaptionResult:
+    """Replace base64 images in markdown with captions."""
     matches = list(IMAGE_RE.finditer(md_content))
     if not matches:
-        return md_content, 0, 0
+        return CaptionResult(markdown=md_content)
 
     skip_indices = _get_skip_indices(pictures)
 
     captioned = 0
     skipped = 0
+    failed = 0
     result = md_content
     image_details = []
 
@@ -131,10 +141,11 @@ async def _caption_images(
             replacement = f"![{caption_text}]"
             captioned += 1
             image_details.append({"index": index, "dimensions": [width, height], "action": "captioned"})
-        except Exception:
-            logger.warning("Captioning failed for image at index %d, using fallback", index)
+        except Exception as e:
+            logger.warning("Captioning failed for image at index %d: %s", index, e)
             replacement = f"![{alt_text or 'Image'}]"
-            image_details.append({"index": index, "dimensions": [width, height], "action": "fallback"})
+            failed += 1
+            image_details.append({"index": index, "dimensions": [width, height], "action": "fallback", "error": str(e)})
 
         result = result[:match.start()] + replacement + result[match.end():]
 
@@ -146,7 +157,7 @@ async def _caption_images(
         "images": image_details,
     })
 
-    return result, captioned, skipped
+    return CaptionResult(markdown=result, captioned=captioned, skipped=skipped, failed=failed)
 
 
 async def convert(file_bytes: bytes, mime_type: str, timeout: float, debug: list[dict] | None = None) -> ConvertResult:
@@ -193,22 +204,52 @@ async def convert(file_bytes: bytes, mime_type: str, timeout: float, debug: list
     })
 
     actions = ["docling"]
+    warnings: list[dict] = []
     images_captioned = 0
     images_skipped = 0
 
-    if captioning.is_available():
-        md_content, images_captioned, images_skipped = await _caption_images(
-            md_content, pictures, timeout, debug
-        )
-        if images_captioned or images_skipped:
-            actions.append(f"captioning ({images_captioned} captioned, {images_skipped} skipped)")
+    image_count = len(list(IMAGE_RE.finditer(md_content)))
 
+    if captioning.is_available() and image_count > 0:
+        cap = await _caption_images(md_content, pictures, timeout, debug)
+        md_content = cap.markdown
+        images_captioned = cap.captioned
+        images_skipped = cap.skipped
+        parts = []
+        if cap.captioned:
+            parts.append(f"{cap.captioned} captioned")
+        if cap.skipped:
+            parts.append(f"{cap.skipped} skipped")
+        if cap.failed:
+            parts.append(f"{cap.failed} failed")
+        actions.append(f"captioning ({', '.join(parts)})")
+        if cap.failed:
+            # Extract error from first failed image for the warning message
+            errors = [d.get("error", "") for d in debug[-1].get("images", []) if d.get("action") == "fallback"]
+            reason = errors[0] if errors else "unknown error"
+            warnings.append({
+                "code": "captioning_failed",
+                "message": f"{cap.failed} image(s) could not be captioned: {reason}",
+                "count": cap.failed,
+                "config": captioning.get_config(),
+            })
+    elif image_count > 0:
+        warnings.append({
+            "code": "captioning_unavailable",
+            "message": f"{image_count} image(s) have no descriptions (captioning not available)",
+            "count": image_count,
+            "config": captioning.get_config(),
+        })
+
+    completeness = "partial" if warnings else "full"
     elapsed = (time.time() - start_time) * 1000
 
     return ConvertResult(
         markdown=md_content,
         detected_type=mime_type,
         actions=actions,
+        warnings=warnings,
+        completeness=completeness,
         processing_time_ms=elapsed,
         images_captioned=images_captioned,
         images_skipped=images_skipped,

--- a/skill/read-document/SKILL.md
+++ b/skill/read-document/SKILL.md
@@ -7,21 +7,31 @@ Read any document using the Canonizr pipeline. Supports PDFs, images, office fil
 
 ## Using Canonizr
 
-You can pass documents to Canonizr via CLI.
+Convert a document to markdown:
 
 ```sh
 canonizr convert document.pdf
 ```
 
-The output of the above command is a direct markdown transcript.
+This writes the markdown to `document.pdf.md` and prints a job summary (JSON) to stdout. If the output file already exists, the conversion is skipped — so it's safe to run repeatedly.
 
-Failed attempts to convert a file return an error message. Depending on context you may wish to store the output in an adjacent `.md` file to avoid re-processing.
+To overwrite an existing output:
 
-Supported file formats include PDFs, images (which will be transcribed), and office files.
+```sh
+canonizr convert document.pdf -f
+```
+
+To get the markdown directly to stdout (for piping):
+
+```sh
+canonizr convert document.pdf -o -
+```
+
+The job JSON includes a `completeness` field (`"full"` or `"partial"`) and a `warnings` array describing any issues (e.g. images that could not be captioned).
 
 ## Debugging
 
-You can check if the Canonizr pipeline is running by using the CLI:
+Check if the Canonizr pipeline is running:
 
 ```sh
 canonizr health
@@ -37,10 +47,4 @@ And stop it with:
 
 ```sh
 canonizr down
-```
-
-You can get a full JSON response with metadata (instead of just markdown) using the `--json` flag:
-
-```sh
-canonizr convert --json document.pdf
 ```


### PR DESCRIPTION
- Captioning endpoint, API key, and model are now configurable via env vars, supporting local Gemma 4, OpenAI, Azure, Nebius, or any OpenAI-compatible API
- CLI writes markdown to <file>.md by default, returns job metadata JSON to stdout — no Python dependency, pure bash + curl
- Gateway returns markdown body + metadata header when Accept: text/markdown is requested
- Warnings and completeness signals surface captioning failures with diagnostic config (endpoint, key presence, model)
- Skips already-converted files (no-overwrite by default, -f to force)

Fix #3 