### PR TITLE
Make LibreOffice optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@
 GATEWAY_PORT=7005
 # CORS_ORIGINS=http://localhost:5173
 
+# LibreOffice (for DOC, PPT, XLS, Apple formats)
+LIBREOFFICE_ENABLED=true
+
 # Captioning (local Gemma 4 via llama-server)
 CAPTIONING_ENABLED=true
 CAPTIONING_MODEL=/models/vision.gguf

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ See [filetypes.md](filetypes.md) for the full list of supported formats.
 If you have run `./bin/setup.sh` then `canonizr` will be added to your PATH.
 
 ```bash
-canonizr convert <file>           # writes <file>.md, job JSON to stdout
+canonizr convert <file>           # writes <file>.md, metadata to stdout
 canonizr convert <file> -o -      # markdown to stdout (for piping)
 canonizr convert <file> -o a.md   # custom output path
 canonizr convert <file> -f        # overwrite existing output
 canonizr convert <file> -q        # quiet, no job JSON
-canonizr up [--fg]                # start the pipeline (--fg for logs)
+canonizr up [--fg]                # start the pipeline (--fg to keep in foreground)
 canonizr down                     # stop the pipeline
 canonizr health                   # check if the service is running
 ```
@@ -61,14 +61,13 @@ Then open http://localhost:5173.
 | Script | Purpose |
 |---|---|
 | `./bin/setup.sh` | One-time configuration (writes `.env`) |
-| `./bin/setup.sh --no-captioning` | Setup without the captioning VLM (~6 GB smaller) |
-| `./bin/up.sh` | Start the pipeline (delegates to `canonizr up`) |
-| `./bin/down.sh` | Stop the pipeline (delegates to `canonizr down`) |
+| `./bin/setup.sh --minimal` | Setup without captioning or LibreOffice (~1 GB) |
+| `./bin/setup.sh --maximal` | Setup with all optional services |
 
 ## Requirements
 
 - Docker + Docker Compose
-- ~8 GB disk (~2 GB without captioning)
+- ~1–8 GB disk depending on configuration
 
 ## Configuration
 
@@ -101,8 +100,8 @@ Any OpenAI-compatible endpoint works (OpenAI, Azure OpenAI, Nebius, etc.).
 |---|---|
 | **Gateway** | Format detection, routing, MarkItDown, pymupdf, Pillow |
 | **Docling** | PDF layout analysis, table extraction, figure classification |
-| **Captioning** | VLM for images, figures, scanned pages (local Gemma 4 or external API) |
-| **LibreOffice** | Legacy format conversion (DOC, PPT, XLS, Apple formats) |
+| **Captioning** | VLM for images, figures, scanned pages (local Gemma 4 or external API). Optional. |
+| **LibreOffice** | Legacy format conversion (DOC, PPT, XLS, Apple formats). Optional. |
 
 Only the gateway port is exposed. All services communicate internally over the Docker network.
 

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# This file registers the command line tool
+# and configures the .env file
 set -euo pipefail
 
 echo "=== Canonizr Pipeline Setup ==="
@@ -26,9 +28,11 @@ fi
 
 # Parse flags
 NO_CAPTIONING=false
+NO_LIBREOFFICE=false
 for arg in "$@"; do
   case "$arg" in
-    --no-captioning) NO_CAPTIONING=true ;;
+    --minimal) NO_CAPTIONING=true; NO_LIBREOFFICE=true ;;
+    --maximal) NO_CAPTIONING=false; NO_LIBREOFFICE=false ;;
   esac
 done
 
@@ -121,6 +125,19 @@ CAPTIONING_N_PREDICT=1024"
   fi
 fi
 
+# LibreOffice setup
+if [ "$NO_LIBREOFFICE" = true ]; then
+  enable_libreoffice="n"
+else
+  echo ""
+  read -rp "Enable LibreOffice? Needed for DOC, PPT, XLS, and Apple formats (~1 GB) (Y/n) " enable_libreoffice
+fi
+if [[ "$enable_libreoffice" =~ ^[Nn]$ ]]; then
+  LIBREOFFICE_ENABLED="false"
+else
+  LIBREOFFICE_ENABLED="true"
+fi
+
 # Gateway port
 echo ""
 read -rp "Gateway port [7005]: " gateway_port
@@ -129,6 +146,7 @@ gateway_port="${gateway_port:-7005}"
 # Write .env
 cat > .env <<EOF
 CAPTIONING_ENABLED=$CAPTIONING_ENABLED
+LIBREOFFICE_ENABLED=$LIBREOFFICE_ENABLED
 GATEWAY_PORT=$gateway_port
 EOF
 
@@ -142,6 +160,3 @@ echo "  .env written."
 echo ""
 echo "  Start the pipeline with: canonizr up"
 echo "  Stop the pipeline with: canonizr down"
-if [ "$CAPTIONING_ENABLED" = "true" ]; then
-  echo "  (captioning service will start automatically)"
-fi

--- a/cli/canonizr
+++ b/cli/canonizr
@@ -68,37 +68,37 @@ cmd_convert() {
   fi
 
   # Request markdown body with metadata in header
-  local tmpfile
+  local tmpfile tmpbody
   tmpfile=$(mktemp)
-  trap 'rm -f "$tmpfile"' RETURN
+  tmpbody=$(mktemp)
+  trap 'rm -f "$tmpfile" "$tmpbody"' RETURN
 
   local http_code metadata
-  if [[ "$output" == "-" ]]; then
-    # Pipe mode: write markdown to stdout via curl
-    metadata=$(curl -sf -D "$tmpfile" \
-      -H "Accept: text/markdown" \
-      -F "file=@${file}" \
-      "${BASE_URL}/convert" 2>/dev/null) || {
-      echo "Error: could not reach Canonizr at ${BASE_URL}" >&2
-      echo "Is the service running? Start it with: canonizr up" >&2
-      exit 1
-    }
-    # markdown went to stdout already via curl, extract metadata from headers
-    metadata=$(grep -i '^x-job-metadata:' "$tmpfile" | sed 's/^[^:]*: //' | tr -d '\r')
-  else
-    # File mode: write markdown directly to output file
-    http_code=$(curl -sf -o "$output" -D "$tmpfile" -w "%{http_code}" \
-      -H "Accept: text/markdown" \
-      -F "file=@${file}" \
-      "${BASE_URL}/convert" 2>/dev/null) || {
-      rm -f "$output"
-      echo "Error: could not reach Canonizr at ${BASE_URL}" >&2
-      echo "Is the service running? Start it with: canonizr up" >&2
-      exit 1
-    }
-    metadata=$(grep -i '^x-job-metadata:' "$tmpfile" | sed 's/^[^:]*: //' | tr -d '\r')
 
-    # Print metadata JSON to stdout
+  # Make the request — capture status code, headers, and body separately
+  http_code=$(curl -s -o "$tmpbody" -D "$tmpfile" -w "%{http_code}" \
+    -H "Accept: text/markdown" \
+    -F "file=@${file}" \
+    "${BASE_URL}/convert" 2>/dev/null) || {
+    echo "Error: could not reach Canonizr at ${BASE_URL}" >&2
+    echo "Is the service running? Start it with: canonizr up" >&2
+    exit 1
+  }
+
+  # Handle HTTP errors
+  if [[ "$http_code" -ge 400 ]]; then
+    echo "Error (HTTP $http_code): $(cat "$tmpbody")" >&2
+    exit 1
+  fi
+
+  metadata=$(grep -i '^x-job-metadata:' "$tmpfile" | sed 's/^[^:]*: //' | tr -d '\r')
+
+  if [[ "$output" == "-" ]]; then
+    # Pipe mode: markdown to stdout
+    cat "$tmpbody"
+  else
+    # File mode: move body to output, metadata to stdout
+    mv "$tmpbody" "$output"
     if [[ "$quiet" != "true" ]] && [[ -n "$metadata" ]]; then
       echo "$metadata"
     fi
@@ -112,6 +112,18 @@ cmd_health() {
   }
 }
 
+_profiles() {
+  # Build profile flags based on .env config
+  local profiles=""
+  if [ "${CAPTIONING_ENABLED:-true}" = "true" ] && [ -z "${CAPTIONING_ENDPOINT:-}" ]; then
+    profiles="$profiles --profile captioning"
+  fi
+  if [ "${LIBREOFFICE_ENABLED:-true}" = "true" ]; then
+    profiles="$profiles --profile libreoffice"
+  fi
+  echo "$profiles"
+}
+
 cmd_up() {
   local detach="-d"
   for arg in "$@"; do
@@ -122,16 +134,12 @@ cmd_up() {
 
   cd "$REPO_ROOT"
   source .env 2>/dev/null || true
-  if [ "${CAPTIONING_ENABLED:-true}" = "true" ] && [ -z "${CAPTIONING_ENDPOINT:-}" ]; then
-    docker compose --profile captioning up $detach --build
-  else
-    docker compose up $detach --build
-  fi
+  docker compose $(_profiles) up $detach --build
 }
 
 cmd_down() {
   cd "$REPO_ROOT"
-  docker compose --profile captioning down
+  docker compose --profile captioning --profile libreoffice down
 }
 
 if [[ $# -lt 1 ]]; then

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - CAPTIONING_ENDPOINT=${CAPTIONING_ENDPOINT:-}
       - CAPTIONING_API_KEY=${CAPTIONING_API_KEY:-}
       - CAPTIONING_API_MODEL=${CAPTIONING_API_MODEL:-}
+      - LIBREOFFICE_ENABLED=${LIBREOFFICE_ENABLED:-true}
       - CORS_ORIGINS=${CORS_ORIGINS:-*}
       - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
       - REQUEST_TIMEOUT=${REQUEST_TIMEOUT:-300}
@@ -74,6 +75,7 @@ services:
       start_period: 30s
 
   libreoffice:
+    profiles: ["libreoffice"]
     build:
       context: ./libreoffice
       dockerfile: libreoffice.dockerfile

--- a/gateway/app/convert.py
+++ b/gateway/app/convert.py
@@ -104,6 +104,11 @@ async def convert(file_bytes: bytes, mime_type: str, filename: str, timeout: flo
 
     # Legacy formats — LibreOffice converts, then re-process
     if mime_type in LIBREOFFICE_TYPES:
+        if not libreoffice.is_available():
+            raise ServiceNotConfigured(
+                f"This file type ({mime_type}) requires LibreOffice. "
+                "Rerun setup to enable it."
+            )
         target = LIBREOFFICE_TYPES[mime_type]
         converted_bytes, converted_mime = await libreoffice.convert(
             file_bytes, mime_type, filename, target, timeout, debug

--- a/gateway/app/services/libreoffice.py
+++ b/gateway/app/services/libreoffice.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from io import BytesIO
 
@@ -8,6 +9,10 @@ from fastapi import HTTPException
 logger = logging.getLogger(__name__)
 
 URL = "http://libreoffice:8000/convert"
+
+
+def is_available() -> bool:
+    return os.environ.get("LIBREOFFICE_ENABLED", "true").lower() == "true"
 
 
 async def convert(file_bytes: bytes, mime_type: str, filename: str, target_format: str, timeout: float, debug: list[dict] | None = None) -> tuple[bytes, str]:


### PR DESCRIPTION
- LibreOffice gated behind docker compose profile and LIBREOFFICE_ENABLED env var, same pattern as captioning
- Graceful 422 error when a file needs LibreOffice but it's not enabled
- CLI no longer swallows HTTP errors — shows actual error message instead of "could not reach Canonizr"
- Setup offers --minimal (no optional services) and --maximal flags
- Docker profiles built dynamically in CLI based on .env config

Fix #5