### PR TITLE
Handle multipage .tiff files

### DIFF
--- a/gateway/app/convert.py
+++ b/gateway/app/convert.py
@@ -6,6 +6,7 @@ from io import BytesIO
 
 from markitdown import MarkItDown
 
+from .imageconv import extract_pages, is_multipage
 from .response import ConvertResult
 from .services import captioning, docling, libreoffice
 
@@ -76,6 +77,21 @@ async def convert(file_bytes: bytes, mime_type: str, filename: str, timeout: flo
             raise ServiceNotConfigured(
                 "Image processing requires the captioning service. "
                 "Set CAPTIONING_ENABLED=true in .env and ensure the captioning container is running."
+            )
+        if is_multipage(mime_type):
+            pages = extract_pages(file_bytes)
+            results = [await captioning.describe_file(p, mt, timeout, debug) for p, mt in pages]
+            markdown = "\n\n---\n\n".join(r.markdown for r in results)
+            elapsed = (time.time() - start_time) * 1000
+            return ConvertResult(
+                markdown=markdown,
+                detected_type=mime_type,
+                actions=["captioning"],
+                processing_time_ms=elapsed,
+                images_captioned=sum(r.images_captioned for r in results),
+                captioning_prompt_tokens=sum(r.captioning_prompt_tokens for r in results),
+                captioning_completion_tokens=sum(r.captioning_completion_tokens for r in results),
+                debug=debug,
             )
         result = await captioning.describe_file(file_bytes, mime_type, timeout, debug)
         result.detected_type = mime_type

--- a/gateway/app/imageconv/__init__.py
+++ b/gateway/app/imageconv/__init__.py
@@ -1,1 +1,3 @@
-from .convert import to_png as to_png
+from .convert import extract_pages as extract_pages
+from .convert import is_multipage as is_multipage
+from .convert import to_native as to_native

--- a/gateway/app/imageconv/convert.py
+++ b/gateway/app/imageconv/convert.py
@@ -6,14 +6,12 @@ from PIL import Image
 NATIVE_TYPES = {
     "image/jpeg",
     "image/png",
-    "image/webp",
-    "image/gif",
-    "image/bmp",
-    "image/tiff",
 }
 
+MULTIPAGE_TYPES = {"image/tiff"}
 
-def to_png(image_bytes: bytes, mime_type: str) -> tuple[bytes, str]:
+
+def to_native(image_bytes: bytes, mime_type: str) -> tuple[bytes, str]:
     """Convert image bytes to PNG if the format isn't natively supported by the VLM.
     Returns (converted_bytes, mime_type)."""
     if mime_type in NATIVE_TYPES:
@@ -23,3 +21,20 @@ def to_png(image_bytes: bytes, mime_type: str) -> tuple[bytes, str]:
     buf = BytesIO()
     img.convert("RGB").save(buf, format="PNG")
     return buf.getvalue(), "image/png"
+
+
+def extract_pages(image_bytes: bytes) -> list[tuple[bytes, str]]:
+    """Extract all pages from a multi-page image (e.g. TIFF) as PNG.
+    Returns a list of (image_bytes, mime_type) tuples."""
+    img = Image.open(BytesIO(image_bytes))
+    pages = []
+    for i in range(getattr(img, "n_frames", 1)):
+        img.seek(i)
+        buf = BytesIO()
+        img.convert("RGB").save(buf, format="PNG")
+        pages.append((buf.getvalue(), "image/png"))
+    return pages
+
+
+def is_multipage(mime_type: str) -> bool:
+    return mime_type in MULTIPAGE_TYPES

--- a/gateway/app/imageconv/convert.py
+++ b/gateway/app/imageconv/convert.py
@@ -10,14 +10,26 @@ NATIVE_TYPES = {
 
 MULTIPAGE_TYPES = {"image/tiff"}
 
+MAX_DIMENSION = 4096
+
+
+def _downscale(img: Image.Image) -> Image.Image:
+    """Downscale to fit within MAX_DIMENSION, preserving aspect ratio."""
+    if max(img.size) > MAX_DIMENSION:
+        img.thumbnail((MAX_DIMENSION, MAX_DIMENSION), Image.Resampling.LANCZOS)
+    return img
+
 
 def to_native(image_bytes: bytes, mime_type: str) -> tuple[bytes, str]:
     """Convert image bytes to PNG if the format isn't natively supported by the VLM.
+    Downscales if either dimension exceeds MAX_DIMENSION.
     Returns (converted_bytes, mime_type)."""
-    if mime_type in NATIVE_TYPES:
+    img = Image.open(BytesIO(image_bytes))
+
+    if mime_type in NATIVE_TYPES and max(img.size) <= MAX_DIMENSION:
         return image_bytes, mime_type
 
-    img = Image.open(BytesIO(image_bytes))
+    _downscale(img)
     buf = BytesIO()
     img.convert("RGB").save(buf, format="PNG")
     return buf.getvalue(), "image/png"
@@ -25,13 +37,16 @@ def to_native(image_bytes: bytes, mime_type: str) -> tuple[bytes, str]:
 
 def extract_pages(image_bytes: bytes) -> list[tuple[bytes, str]]:
     """Extract all pages from a multi-page image (e.g. TIFF) as PNG.
+    Downscales pages that exceed MAX_DIMENSION.
     Returns a list of (image_bytes, mime_type) tuples."""
     img = Image.open(BytesIO(image_bytes))
     pages = []
     for i in range(getattr(img, "n_frames", 1)):
         img.seek(i)
+        frame = img.convert("RGB")
+        _downscale(frame)
         buf = BytesIO()
-        img.convert("RGB").save(buf, format="PNG")
+        frame.save(buf, format="PNG")
         pages.append((buf.getvalue(), "image/png"))
     return pages
 

--- a/gateway/app/services/captioning.py
+++ b/gateway/app/services/captioning.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 import httpx
 from fastapi import HTTPException
 
-from ..imageconv import to_png
+from ..imageconv import to_native
 from ..prompts import IMAGE
 from ..response import ConvertResult
 
@@ -108,7 +108,7 @@ async def describe_file(image_bytes: bytes, mime_type: str, timeout: float, debu
     """Describe a standalone image upload."""
     if debug is None:
         debug = []
-    image_bytes, mime_type = to_png(image_bytes, mime_type)
+    image_bytes, mime_type = to_native(image_bytes, mime_type)
     image_b64 = base64.b64encode(image_bytes).decode("utf-8")
     result = await _call(image_b64, mime_type, timeout)
     debug.append({"step": "captioning", "elapsed_ms": result.elapsed_ms, "output_length": len(result.text)})

--- a/gateway/tests/integration/conftest.py
+++ b/gateway/tests/integration/conftest.py
@@ -80,6 +80,19 @@ def make_pdf_with_images(images: list[EmbeddedImage], text: str = "Document with
     return buf.getvalue()
 
 
+def make_tiff(pages: list[str]) -> bytes:
+    """Generate a multi-page TIFF with text drawn on each page."""
+    frames = []
+    for text in pages:
+        img = Image.new("RGB", (200, 100), color="white")
+        draw = ImageDraw.Draw(img)
+        draw.text((10, 40), text, fill="black")
+        frames.append(img)
+    buf = io.BytesIO()
+    frames[0].save(buf, format="TIFF", save_all=True, append_images=frames[1:])
+    return buf.getvalue()
+
+
 def make_docx(text: str = "This is a test Word document.") -> bytes:
     """Generate a simple DOCX."""
     doc = Document()

--- a/gateway/tests/integration/test_captioning.py
+++ b/gateway/tests/integration/test_captioning.py
@@ -1,7 +1,7 @@
 """Test captioning service paths."""
 import io
 import requests
-from conftest import GATEWAY_URL, TIMEOUT, make_png
+from conftest import GATEWAY_URL, TIMEOUT, make_png, make_tiff
 
 
 def test_image_returns_text():
@@ -14,7 +14,7 @@ def test_image_returns_text():
     assert r.status_code == 200
     data = r.json()
     assert len(data["markdown"]) > 0
-    assert "transcription" in data["metadata"]["actions"]
+    assert "captioning" in data["metadata"]["actions"]
 
 
 def test_image_caption_not_empty():
@@ -27,5 +27,21 @@ def test_image_caption_not_empty():
     )
     assert r.status_code == 200
     data = r.json()
-    # Should be more than just whitespace
     assert len(data["markdown"].strip()) > 5
+
+
+def test_multipage_tiff():
+    """A multi-page TIFF should produce one section per page, separated by ---."""
+    tiff_bytes = make_tiff(["Page One", "Page Two", "Page Three"])
+    r = requests.post(
+        f"{GATEWAY_URL}/convert",
+        files={"file": ("scan.tiff", io.BytesIO(tiff_bytes), "image/tiff")},
+        timeout=TIMEOUT,
+    )
+    assert r.status_code == 200
+    data = r.json()
+    sections = data["markdown"].split("---")
+    assert len(sections) == 3
+    for section in sections:
+        assert len(section.strip()) > 0
+    assert data["metadata"]["captioning"]["images_captioned"] == 3

--- a/gateway/tests/unit/test_imageconv.py
+++ b/gateway/tests/unit/test_imageconv.py
@@ -1,0 +1,81 @@
+"""Unit tests for image conversion and multi-page extraction."""
+from io import BytesIO
+
+from PIL import Image
+
+from app.imageconv import extract_pages, is_multipage, to_native
+
+
+def _make_image(color, fmt="PNG", mime="image/png"):
+    """Create a single solid-color image."""
+    img = Image.new("RGB", (100, 100), color)
+    buf = BytesIO()
+    img.save(buf, format=fmt)
+    return buf.getvalue(), mime
+
+
+def _make_multipage_tiff(colors):
+    """Create a multi-page TIFF from a list of colors."""
+    frames = [Image.new("RGB", (100, 100), c) for c in colors]
+    buf = BytesIO()
+    frames[0].save(buf, format="TIFF", save_all=True, append_images=frames[1:])
+    return buf.getvalue()
+
+
+class TestToNative:
+    def test_png_passthrough(self):
+        data, _ = _make_image("red", "PNG", "image/png")
+        out, out_mime = to_native(data, "image/png")
+        assert out is data
+        assert out_mime == "image/png"
+
+    def test_jpeg_passthrough(self):
+        data, _ = _make_image("blue", "JPEG", "image/jpeg")
+        out, out_mime = to_native(data, "image/jpeg")
+        assert out is data
+        assert out_mime == "image/jpeg"
+
+    def test_tiff_converted_to_webp(self):
+        data, _ = _make_image("green", "TIFF", "image/tiff")
+        out, out_mime = to_native(data, "image/tiff")
+        assert out_mime == "image/png"
+        assert out != data
+        img = Image.open(BytesIO(out))
+        assert img.format == "PNG"
+
+    def test_bmp_converted_to_webp(self):
+        data, _ = _make_image("yellow", "BMP", "image/bmp")
+        _, out_mime = to_native(data, "image/bmp")
+        assert out_mime == "image/png"
+
+
+class TestIsMultipage:
+    def test_tiff_is_multipage(self):
+        assert is_multipage("image/tiff") is True
+
+    def test_png_is_not_multipage(self):
+        assert is_multipage("image/png") is False
+
+    def test_jpeg_is_not_multipage(self):
+        assert is_multipage("image/jpeg") is False
+
+
+class TestExtractPages:
+    def test_extracts_all_pages(self):
+        tiff_bytes = _make_multipage_tiff(["red", "green", "blue"])
+        pages = extract_pages(tiff_bytes)
+        assert len(pages) == 3
+        for page_bytes, mime in pages:
+            assert mime == "image/png"
+            img = Image.open(BytesIO(page_bytes))
+            assert img.format == "PNG"
+
+    def test_single_page_tiff(self):
+        tiff_bytes = _make_multipage_tiff(["red"])
+        pages = extract_pages(tiff_bytes)
+        assert len(pages) == 1
+
+    def test_pages_have_distinct_content(self):
+        tiff_bytes = _make_multipage_tiff(["red", "blue"])
+        pages = extract_pages(tiff_bytes)
+        assert pages[0][0] != pages[1][0]

--- a/gateway/tests/unit/test_imageconv.py
+++ b/gateway/tests/unit/test_imageconv.py
@@ -6,9 +6,9 @@ from PIL import Image
 from app.imageconv import extract_pages, is_multipage, to_native
 
 
-def _make_image(color, fmt="PNG", mime="image/png"):
+def _make_image(color, fmt="PNG", mime="image/png", size=(100, 100)):
     """Create a single solid-color image."""
-    img = Image.new("RGB", (100, 100), color)
+    img = Image.new("RGB", size, color)
     buf = BytesIO()
     img.save(buf, format=fmt)
     return buf.getvalue(), mime
@@ -35,7 +35,7 @@ class TestToNative:
         assert out is data
         assert out_mime == "image/jpeg"
 
-    def test_tiff_converted_to_webp(self):
+    def test_tiff_converted_to_png(self):
         data, _ = _make_image("green", "TIFF", "image/tiff")
         out, out_mime = to_native(data, "image/tiff")
         assert out_mime == "image/png"
@@ -43,10 +43,31 @@ class TestToNative:
         img = Image.open(BytesIO(out))
         assert img.format == "PNG"
 
-    def test_bmp_converted_to_webp(self):
+    def test_bmp_converted_to_png(self):
         data, _ = _make_image("yellow", "BMP", "image/bmp")
         _, out_mime = to_native(data, "image/bmp")
         assert out_mime == "image/png"
+
+    def test_large_png_downscaled(self):
+        data, _ = _make_image("red", "PNG", "image/png", size=(8000, 6000))
+        out, out_mime = to_native(data, "image/png")
+        assert out_mime == "image/png"
+        assert out is not data
+        img = Image.open(BytesIO(out))
+        assert max(img.size) == 4096
+
+    def test_small_png_not_downscaled(self):
+        data, _ = _make_image("red", "PNG", "image/png", size=(2000, 1000))
+        out, out_mime = to_native(data, "image/png")
+        assert out is data
+
+    def test_large_tiff_downscaled(self):
+        data, _ = _make_image("blue", "TIFF", "image/tiff", size=(6000, 8000))
+        out, out_mime = to_native(data, "image/tiff")
+        assert out_mime == "image/png"
+        img = Image.open(BytesIO(out))
+        assert max(img.size) == 4096
+        assert img.size[1] == 4096  # height was the long side
 
 
 class TestIsMultipage:


### PR DESCRIPTION
Ensure that multipage .tiff files are split into individual png files before further processing

Also downscales enormous images (4096px max side length)