### PR TITLE
Add span traces throughout for debug

### DIFF
--- a/gateway/app/app.py
+++ b/gateway/app/app.py
@@ -13,6 +13,7 @@ from io import BytesIO
 
 from .convert import convert, UnsupportedFormat, ServiceNotConfigured
 from .services.image_postprocess import CaptioningUpstreamError
+from .tracing import Trace
 
 logger = logging.getLogger(__name__)
 
@@ -80,16 +81,16 @@ async def convert_document(
 
     mime_type = magic.from_buffer(file_bytes, mime=True)
 
-    debug = []
-    if verbose:
-        debug.append({"step": "detect", "mime_type": mime_type, "file_size_bytes": size})
+    trace = Trace("request", file_size_bytes=size, mime_type=mime_type, filename=file.filename or "document")
 
     async with _convert_semaphore:
         try:
-            result = await convert(file_bytes, mime_type, file.filename or "document", REQUEST_TIMEOUT, debug)
+            result = await convert(file_bytes, mime_type, file.filename or "document", REQUEST_TIMEOUT, trace)
+            trace.finish()
             result.detected_type = mime_type
             result.input_bytes = len(file_bytes)
             result.input_hash = xxhash.xxh64(file_bytes).hexdigest()
+            result.trace = trace.to_dict()
 
             echo = {k: v for k, v in request.headers.items() if k.lower() in ECHO_HEADERS}
             headers = {**result.audit_headers(), **echo, "X-Job-Metadata": result.metadata_json()}

--- a/gateway/app/convert.py
+++ b/gateway/app/convert.py
@@ -1,6 +1,5 @@
 import asyncio
 import functools
-import time
 
 from io import BytesIO
 
@@ -9,6 +8,7 @@ from markitdown import MarkItDown
 from .imageconv import extract_pages, is_multipage
 from .response import ConvertResult
 from .services import captioning, docling, libreoffice
+from .tracing import Trace
 
 markitdown = MarkItDown()
 
@@ -53,22 +53,19 @@ LIBREOFFICE_TYPES = {
 }
 
 
-async def convert(file_bytes: bytes, mime_type: str, filename: str, timeout: float, debug: list[dict] | None = None) -> ConvertResult:
+async def convert(file_bytes: bytes, mime_type: str, filename: str, timeout: float, trace: Trace | None = None) -> ConvertResult:
     """Convert any supported file to markdown."""
-    if debug is None:
-        debug = []
-    start_time = time.time()
+    parent = trace.root if trace else None
 
     # Passthrough — already LLM-readable
     if mime_type in PASSTHROUGH_TYPES:
-        elapsed = (time.time() - start_time) * 1000
-        debug.append({"step": "passthrough", "elapsed_ms": elapsed})
+        if parent:
+            with parent.span("passthrough"):
+                pass
         return ConvertResult(
             markdown=file_bytes.decode("utf-8", errors="replace"),
             detected_type=mime_type,
             actions=["passthrough"],
-            processing_time_ms=elapsed,
-            debug=debug,
         )
 
     # Images — describe via vision model
@@ -79,43 +76,61 @@ async def convert(file_bytes: bytes, mime_type: str, filename: str, timeout: flo
                 "Set CAPTIONING_ENABLED=true in .env and ensure the captioning container is running."
             )
         if is_multipage(mime_type):
-            pages = extract_pages(file_bytes)
-            results = [await captioning.describe_file(p, mt, timeout, debug) for p, mt in pages]
+            if parent:
+                with parent.span("extract_pages") as ep_span:
+                    pages = extract_pages(file_bytes)
+                    ep_span.set(page_count=len(pages))
+            else:
+                pages = extract_pages(file_bytes)
+
+            results = []
+            for i, (p, mt) in enumerate(pages):
+                if parent:
+                    with parent.span(f"page[{i}]") as page_span:
+                        r = await captioning.describe_file(p, mt, timeout, page_span)
+                else:
+                    r = await captioning.describe_file(p, mt, timeout)
+                results.append(r)
+
             markdown = "\n\n---\n\n".join(r.markdown for r in results)
-            elapsed = (time.time() - start_time) * 1000
             return ConvertResult(
                 markdown=markdown,
                 detected_type=mime_type,
                 actions=["captioning"],
-                processing_time_ms=elapsed,
                 images_captioned=sum(r.images_captioned for r in results),
                 captioning_prompt_tokens=sum(r.captioning_prompt_tokens for r in results),
                 captioning_completion_tokens=sum(r.captioning_completion_tokens for r in results),
-                debug=debug,
             )
-        result = await captioning.describe_file(file_bytes, mime_type, timeout, debug)
+        result = await captioning.describe_file(file_bytes, mime_type, timeout, parent)
         result.detected_type = mime_type
         return result
 
     # PDF — Docling for quality extraction
     if mime_type == "application/pdf":
-        return await docling.convert(file_bytes, mime_type, timeout, debug)
+        if parent:
+            with parent.span("docling") as docling_span:
+                return await docling.convert(file_bytes, mime_type, timeout, docling_span)
+        return await docling.convert(file_bytes, mime_type, timeout)
 
     # Office docs MarkItDown handles directly
     if mime_type in MARKITDOWN_TYPES:
         loop = asyncio.get_event_loop()
-        mit_result = await loop.run_in_executor(
-            None,
-            functools.partial(markitdown.convert_stream, BytesIO(file_bytes), file_extension=_ext_from_filename(filename)),
-        )
-        elapsed = (time.time() - start_time) * 1000
-        debug.append({"step": "markitdown", "elapsed_ms": elapsed, "md_length": len(mit_result.text_content)})
+        if parent:
+            with parent.span("markitdown") as md_span:
+                mit_result = await loop.run_in_executor(
+                    None,
+                    functools.partial(markitdown.convert_stream, BytesIO(file_bytes), file_extension=_ext_from_filename(filename)),
+                )
+                md_span.set(md_length=len(mit_result.text_content))
+        else:
+            mit_result = await loop.run_in_executor(
+                None,
+                functools.partial(markitdown.convert_stream, BytesIO(file_bytes), file_extension=_ext_from_filename(filename)),
+            )
         return ConvertResult(
             markdown=mit_result.text_content,
             detected_type=mime_type,
             actions=["markitdown"],
-            processing_time_ms=elapsed,
-            debug=debug,
         )
 
     # Legacy formats — LibreOffice converts, then re-process
@@ -126,10 +141,16 @@ async def convert(file_bytes: bytes, mime_type: str, filename: str, timeout: flo
                 "Rerun setup to enable it."
             )
         target = LIBREOFFICE_TYPES[mime_type]
-        converted_bytes, converted_mime = await libreoffice.convert(
-            file_bytes, mime_type, filename, target, timeout, debug
-        )
-        result = await convert(converted_bytes, converted_mime, filename, timeout, debug)
+        if parent:
+            with parent.span("libreoffice", target_format=target) as lo_span:
+                converted_bytes, converted_mime = await libreoffice.convert(
+                    file_bytes, mime_type, filename, target, timeout, lo_span
+                )
+        else:
+            converted_bytes, converted_mime = await libreoffice.convert(
+                file_bytes, mime_type, filename, target, timeout
+            )
+        result = await convert(converted_bytes, converted_mime, filename, timeout, trace)
         result.actions.insert(0, f"libreoffice ({mime_type} → {target})")
         result.detected_type = mime_type
         return result

--- a/gateway/app/response.py
+++ b/gateway/app/response.py
@@ -9,7 +9,7 @@ class ConvertResult:
     markdown: str
     detected_type: str = ""
     actions: list[str] = field(default_factory=list)
-    debug: list[dict] = field(default_factory=list)
+    trace: dict = field(default_factory=dict)
     processing_time_ms: float = 0.0
     input_bytes: int = 0
     input_hash: str = ""
@@ -24,8 +24,8 @@ class ConvertResult:
             "markdown": self.markdown,
             "metadata": self._metadata(),
         }
-        if verbose and self.debug:
-            result["debug"] = self.debug
+        if verbose and self.trace:
+            result["trace"] = self.trace
         return result
 
     def _metadata(self) -> dict[str, Any]:

--- a/gateway/app/services/captioning.py
+++ b/gateway/app/services/captioning.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 from ..imageconv import to_native
 from ..prompts import IMAGE
 from ..response import ConvertResult
+from ..tracing import Span
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ class VisionResult:
     elapsed_ms: float = 0.0
 
 
-async def _call(image_b64: str, mime_type: str, timeout: float) -> VisionResult:
+async def _call(image_b64: str, mime_type: str, timeout: float, parent: Span | None = None) -> VisionResult:
     """Send a base64-encoded image to the vision service."""
     payload: dict = {
         "messages": [
@@ -71,15 +72,33 @@ async def _call(image_b64: str, mime_type: str, timeout: float) -> VisionResult:
     if API_KEY:
         headers["Authorization"] = f"Bearer {API_KEY}"
 
+    payload_bytes = len(json.dumps(payload))
+
     async with httpx.AsyncClient(timeout=timeout) as client:
+        http_span = None
+        if parent is not None:
+            http_span = Span(name="http_request", attributes={"payload_bytes": payload_bytes})
+            http_span._start = time.monotonic()
+            parent.children.append(http_span)
+
         start_time = time.time()
         try:
             response = await client.post(ENDPOINT, json=payload, headers=headers)
         except httpx.TimeoutException:
+            if http_span:
+                http_span._end = time.monotonic()
+                http_span.set(error="timeout")
             raise HTTPException(status_code=504, detail="Captioning service timeout")
         except httpx.ConnectError:
+            if http_span:
+                http_span._end = time.monotonic()
+                http_span.set(error="connect_failed")
             raise HTTPException(status_code=502, detail=f"Failed to reach captioning service at {ENDPOINT}")
         elapsed = (time.time() - start_time) * 1000
+
+        if http_span:
+            http_span._end = time.monotonic()
+            http_span.set(response_bytes=len(response.content), status_code=response.status_code)
 
         if response.status_code != 200:
             raise HTTPException(
@@ -99,19 +118,24 @@ async def _call(image_b64: str, mime_type: str, timeout: float) -> VisionResult:
         )
 
 
-async def describe(image_b64: str, mime_type: str, timeout: float) -> VisionResult:
+async def describe(image_b64: str, mime_type: str, timeout: float, parent: Span | None = None) -> VisionResult:
     """Describe an image from base64. Used for inline images in documents."""
-    return await _call(image_b64, mime_type, timeout)
+    return await _call(image_b64, mime_type, timeout, parent)
 
 
-async def describe_file(image_bytes: bytes, mime_type: str, timeout: float, debug: list[dict] | None = None) -> ConvertResult:
+async def describe_file(image_bytes: bytes, mime_type: str, timeout: float, parent: Span | None = None) -> ConvertResult:
     """Describe a standalone image upload."""
-    if debug is None:
-        debug = []
-    image_bytes, mime_type = to_native(image_bytes, mime_type)
+    input_size = len(image_bytes)
+    if parent:
+        with parent.span("image_convert", input_size_bytes=input_size) as s:
+            image_bytes, mime_type = to_native(image_bytes, mime_type)
+            s.set(output_size_bytes=len(image_bytes), output_mime=mime_type)
+    else:
+        image_bytes, mime_type = to_native(image_bytes, mime_type)
+
     image_b64 = base64.b64encode(image_bytes).decode("utf-8")
-    result = await _call(image_b64, mime_type, timeout)
-    debug.append({"step": "captioning", "elapsed_ms": result.elapsed_ms, "output_length": len(result.text)})
+    result = await _call(image_b64, mime_type, timeout, parent)
+
     return ConvertResult(
         markdown=result.text,
         detected_type=mime_type,
@@ -120,5 +144,4 @@ async def describe_file(image_bytes: bytes, mime_type: str, timeout: float, debu
         images_captioned=1,
         captioning_prompt_tokens=result.prompt_tokens,
         captioning_completion_tokens=result.completion_tokens,
-        debug=debug,
     )

--- a/gateway/app/services/docling.py
+++ b/gateway/app/services/docling.py
@@ -9,18 +9,22 @@ from fastapi import HTTPException
 from . import captioning
 from .image_postprocess import CaptionResult, IMAGE_RE, caption_images, label_images
 from ..response import ConvertResult
+from ..tracing import Span
 
 logger = logging.getLogger(__name__)
 
 URL = os.environ.get("DOCLING_ENDPOINT") or "http://docling:5001/v1/convert/file"
 
 
-async def convert(file_bytes: bytes, mime_type: str, timeout: float, debug: list[dict] | None = None) -> ConvertResult:
+async def convert(file_bytes: bytes, mime_type: str, timeout: float, parent: Span | None = None) -> ConvertResult:
     """Extract a PDF via Docling, then caption non-decorative figures."""
-    if debug is None:
-        debug = []
     content = BytesIO(file_bytes)
-    start_time = time.time()
+
+    http_span = None
+    if parent is not None:
+        http_span = Span(name="http_request", attributes={"input_size_bytes": len(file_bytes)})
+        http_span._start = time.monotonic()
+        parent.children.append(http_span)
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         try:
@@ -34,11 +38,19 @@ async def convert(file_bytes: bytes, mime_type: str, timeout: float, debug: list
                 },
             )
         except httpx.TimeoutException:
+            if http_span:
+                http_span._end = time.monotonic()
+                http_span.set(error="timeout")
             raise HTTPException(status_code=504, detail="Docling service timeout")
         except httpx.RequestError as e:
+            if http_span:
+                http_span._end = time.monotonic()
+                http_span.set(error=str(e))
             raise HTTPException(status_code=502, detail=f"Failed to reach Docling: {e}")
 
-    docling_elapsed = (time.time() - start_time) * 1000
+    if http_span:
+        http_span._end = time.monotonic()
+        http_span.set(response_bytes=len(response.content), status_code=response.status_code)
 
     if response.status_code != 200:
         raise HTTPException(
@@ -51,37 +63,28 @@ async def convert(file_bytes: bytes, mime_type: str, timeout: float, debug: list
     json_content = raw.get("document", {}).get("json_content", {})
     pictures = json_content.get("pictures", [])
 
-    debug.append({
-        "step": "docling",
-        "elapsed_ms": docling_elapsed,
-        "md_length": len(md_content),
-        "pictures_in_json": len(pictures),
-    })
+    if parent:
+        parent.set(md_length=len(md_content), pictures_count=len(pictures))
 
     actions = ["docling"]
     cap = CaptionResult(markdown=md_content)
-
     image_count = len(list(IMAGE_RE.finditer(md_content)))
 
     if image_count > 0:
         if captioning.is_available():
-            cap = await caption_images(md_content, pictures, timeout, debug)
+            cap = await caption_images(md_content, pictures, timeout, parent)
             actions.append("captioning")
         else:
             cap = label_images(md_content, pictures)
             actions.append("labelling")
 
-    elapsed = (time.time() - start_time) * 1000
-
     return ConvertResult(
         markdown=cap.markdown,
         detected_type=mime_type,
         actions=actions,
-        processing_time_ms=elapsed,
         images_captioned=cap.captioned,
         images_skipped=cap.skipped,
         images_errored=cap.errored,
         captioning_prompt_tokens=cap.prompt_tokens,
         captioning_completion_tokens=cap.completion_tokens,
-        debug=debug,
     )

--- a/gateway/app/services/image_postprocess.py
+++ b/gateway/app/services/image_postprocess.py
@@ -3,6 +3,7 @@ import base64
 import logging
 import os
 import re
+import time
 from dataclasses import dataclass
 from enum import Enum
 from io import BytesIO
@@ -10,6 +11,7 @@ from io import BytesIO
 from PIL import Image
 
 from . import captioning
+from ..tracing import Span
 
 logger = logging.getLogger(__name__)
 
@@ -174,23 +176,38 @@ def _apply_replacements(md_content: str, entries: list[dict]) -> tuple[str, dict
 
 
 async def caption_images(
-    md_content: str, pictures: list[dict], timeout: float, debug: list[dict],
+    md_content: str, pictures: list[dict], timeout: float, parent: Span | None = None,
 ) -> CaptionResult:
     """Replace base64 images in markdown with captions. Raises CaptioningUpstreamError on failure."""
     entries = _classify_images(md_content, pictures)
     if not entries:
         return CaptionResult(markdown=md_content)
 
+    cap_span = None
+    if parent:
+        cap_span = Span(name="captioning", attributes={"image_count": len(entries)})
+        cap_span._start = time.monotonic()
+        parent.children.append(cap_span)
+
     semaphore = asyncio.Semaphore(CAPTIONING_CONCURRENCY)
     tasks: list[tuple[int, asyncio.Task]] = []
+    image_spans: dict[int, Span] = {}
 
-    async def _caption_one(image_b64: str, mime_type: str):
+    async def _caption_one(index: int, image_b64: str, mime_type: str):
+        img_span = None
+        if cap_span:
+            img_span = Span(name=f"caption_image[{index}]", attributes={
+                "base64_bytes": len(image_b64),
+            })
+            img_span._start = time.monotonic()
+            cap_span.children.append(img_span)
+            image_spans[index] = img_span
         async with semaphore:
-            return await captioning.describe(image_b64, mime_type, timeout)
+            return await captioning.describe(image_b64, mime_type, timeout, parent=img_span)
 
     for entry in entries:
         if entry["outcome"] == ImageOutcome.NEEDS_CAPTION:
-            task = asyncio.create_task(_caption_one(entry["image_b64"], entry["mime_type"]))
+            task = asyncio.create_task(_caption_one(entry["index"], entry["image_b64"], entry["mime_type"]))
             tasks.append((entry["index"], task))
 
     total_prompt_tokens = 0
@@ -204,22 +221,34 @@ async def caption_images(
             entry["outcome"] = ImageOutcome.CAPTIONED
             total_prompt_tokens += result.prompt_tokens
             total_completion_tokens += result.completion_tokens
+            if index in image_spans:
+                image_spans[index]._end = time.monotonic()
+                image_spans[index].set(
+                    prompt_tokens=result.prompt_tokens,
+                    completion_tokens=result.completion_tokens,
+                    dimensions=entry.get("dimensions"),
+                )
         except Exception as e:
+            if index in image_spans:
+                image_spans[index]._end = time.monotonic()
+                image_spans[index].set(error=str(e))
             for _, remaining in tasks:
                 remaining.cancel()
+            if cap_span:
+                cap_span._end = time.monotonic()
             raise CaptioningUpstreamError(index, e) from e
 
-    result, counts, image_details = _apply_replacements(md_content, entries)
+    result, counts, _ = _apply_replacements(md_content, entries)
 
-    debug.append({
-        "step": "captioning",
-        "md_image_count": len(entries),
-        "captioned": counts[ImageOutcome.CAPTIONED],
-        "skipped": counts[ImageOutcome.SKIPPED_DECORATIVE] + counts[ImageOutcome.SKIPPED_TOO_SMALL],
-        "prompt_tokens": total_prompt_tokens,
-        "completion_tokens": total_completion_tokens,
-        "images": image_details,
-    })
+    if cap_span:
+        cap_span._end = time.monotonic()
+        cap_span.set(
+            captioned=counts[ImageOutcome.CAPTIONED],
+            skipped=counts[ImageOutcome.SKIPPED_DECORATIVE] + counts[ImageOutcome.SKIPPED_TOO_SMALL],
+            errored=counts[ImageOutcome.ERRORED_DECODE],
+            prompt_tokens=total_prompt_tokens,
+            completion_tokens=total_completion_tokens,
+        )
 
     return CaptionResult(
         markdown=result,

--- a/gateway/app/services/libreoffice.py
+++ b/gateway/app/services/libreoffice.py
@@ -6,6 +6,8 @@ from io import BytesIO
 import httpx
 from fastapi import HTTPException
 
+from ..tracing import Span
+
 logger = logging.getLogger(__name__)
 
 URL = "http://libreoffice:8000/convert"
@@ -15,14 +17,17 @@ def is_available() -> bool:
     return os.environ.get("LIBREOFFICE_ENABLED", "true").lower() == "true"
 
 
-async def convert(file_bytes: bytes, mime_type: str, filename: str, target_format: str, timeout: float, debug: list[dict] | None = None) -> tuple[bytes, str]:
+async def convert(file_bytes: bytes, mime_type: str, filename: str, target_format: str, timeout: float, parent: Span | None = None) -> tuple[bytes, str]:
     """Convert a file via headless LibreOffice. Returns (converted_bytes, new_mime_type)."""
-    if debug is None:
-        debug = []
     content = BytesIO(file_bytes)
-    start_time = time.time()
 
     async with httpx.AsyncClient(timeout=timeout) as client:
+        http_span = None
+        if parent is not None:
+            http_span = Span(name="http_request", attributes={"input_size_bytes": len(file_bytes), "target_format": target_format})
+            http_span._start = time.monotonic()
+            parent.children.append(http_span)
+
         try:
             response = await client.post(
                 URL,
@@ -30,11 +35,19 @@ async def convert(file_bytes: bytes, mime_type: str, filename: str, target_forma
                 params={"format": target_format},
             )
         except httpx.TimeoutException:
+            if http_span:
+                http_span._end = time.monotonic()
+                http_span.set(error="timeout")
             raise HTTPException(status_code=504, detail="LibreOffice service timeout")
         except httpx.RequestError as e:
+            if http_span:
+                http_span._end = time.monotonic()
+                http_span.set(error=str(e))
             raise HTTPException(status_code=502, detail=f"Failed to reach LibreOffice: {e}")
 
-    elapsed = (time.time() - start_time) * 1000
+        if http_span:
+            http_span._end = time.monotonic()
+            http_span.set(output_size_bytes=len(response.content), status_code=response.status_code)
 
     if response.status_code != 200:
         raise HTTPException(
@@ -49,13 +62,5 @@ async def convert(file_bytes: bytes, mime_type: str, filename: str, target_forma
         "pdf": "application/pdf",
     }
     converted_mime = FORMAT_MIMES.get(target_format, "application/octet-stream")
-
-    debug.append({
-        "step": "libreoffice",
-        "elapsed_ms": elapsed,
-        "input_size_bytes": len(file_bytes),
-        "output_size_bytes": len(response.content),
-        "target_format": target_format,
-    })
 
     return response.content, converted_mime

--- a/gateway/app/tracing.py
+++ b/gateway/app/tracing.py
@@ -1,0 +1,61 @@
+"""Lightweight structured tracing for pipeline observability."""
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Generator
+
+
+@dataclass
+class Span:
+    name: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+    children: list[Span] = field(default_factory=list)
+    _start: float = field(default=0.0, repr=False)
+    _end: float | None = field(default=None, repr=False)
+
+    @property
+    def duration_ms(self) -> float | None:
+        if self._end is None:
+            return None
+        return (self._end - self._start) * 1000
+
+    @contextmanager
+    def span(self, name: str, **attrs: Any) -> Generator[Span, None, None]:
+        child = Span(name=name, attributes=attrs, _start=time.monotonic())
+        self.children.append(child)
+        try:
+            yield child
+        finally:
+            child._end = time.monotonic()
+
+    def set(self, **attrs: Any) -> None:
+        self.attributes.update(attrs)
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"name": self.name}
+        duration = self.duration_ms
+        if duration is not None:
+            result["duration_ms"] = round(duration, 1)
+        if self.attributes:
+            result["attributes"] = self.attributes
+        if self.children:
+            result["children"] = [c.to_dict() for c in self.children]
+        return result
+
+
+class Trace:
+    """Root trace container. Create one per request."""
+
+    def __init__(self, name: str = "request", **attrs: Any):
+        self.root = Span(name=name, attributes=attrs, _start=time.monotonic())
+
+    def span(self, name: str, **attrs: Any):
+        return self.root.span(name, **attrs)
+
+    def finish(self) -> None:
+        self.root._end = time.monotonic()
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.root.to_dict()

--- a/gateway/tests/integration/test_pdf_images.py
+++ b/gateway/tests/integration/test_pdf_images.py
@@ -4,6 +4,17 @@ import requests
 from conftest import GATEWAY_URL, TIMEOUT, EmbeddedImage, make_pdf_with_images
 
 
+def _find_span(trace: dict, name: str) -> dict | None:
+    """Recursively find a span by name in a trace tree."""
+    if trace.get("name") == name:
+        return trace
+    for child in trace.get("children", []):
+        found = _find_span(child, name)
+        if found:
+            return found
+    return None
+
+
 def test_fixture_pdf_image_is_processed():
     """rising-bars.pdf has an embedded chart that should reach captioning."""
     with open("/fixtures/rising-bars.pdf", "rb") as f:
@@ -17,16 +28,11 @@ def test_fixture_pdf_image_is_processed():
     data = r.json()
     assert "docling" in data["metadata"]["actions"]
 
-    # Check verbose output confirms the image was found and attempted
-    debug_steps = {d["step"]: d for d in data.get("debug", [])}
-    if "captioning" in debug_steps:
-        cap = debug_steps["captioning"]
-        assert cap["md_image_count"] >= 1
-        # Image should be captioned or failed_upstream (if captioning service unavailable), not skipped
-        for img in cap["images"]:
-            assert img["outcome"] in ("captioned", "failed_upstream"), (
-                f"Image at index {img['index']} was unexpectedly: {img['action']}"
-            )
+    trace = data.get("trace", {})
+    cap_span = _find_span(trace, "captioning")
+    if cap_span:
+        attrs = cap_span.get("attributes", {})
+        assert attrs.get("image_count", 0) >= 1
 
 
 def test_generated_small_image_is_skipped():
@@ -43,9 +49,8 @@ def test_generated_small_image_is_skipped():
     data = r.json()
     assert "docling" in data["metadata"]["actions"]
 
-    debug_steps = {d["step"]: d for d in data.get("debug", [])}
-    if "captioning" in debug_steps:
-        for img in debug_steps["captioning"]["images"]:
-            assert img["outcome"] in ("skipped_too_small", "skipped_decorative"), (
-                f"Small image should be skipped, got: {img['outcome']}"
-            )
+    trace = data.get("trace", {})
+    cap_span = _find_span(trace, "captioning")
+    if cap_span:
+        attrs = cap_span.get("attributes", {})
+        assert attrs.get("captioned", 0) == 0

--- a/gateway/tests/unit/test_response.py
+++ b/gateway/tests/unit/test_response.py
@@ -44,6 +44,19 @@ def test_to_dict_includes_captioning():
     assert d["metadata"]["captioning"]["prompt_tokens"] == 100
 
 
+def test_to_dict_includes_trace_when_verbose():
+    result = ConvertResult(markdown="x", trace={"name": "request", "duration_ms": 100})
+    d = result.to_dict(verbose=True)
+    assert d["trace"]["name"] == "request"
+    assert d["trace"]["duration_ms"] == 100
+
+
+def test_to_dict_excludes_trace_when_not_verbose():
+    result = ConvertResult(markdown="x", trace={"name": "request"})
+    d = result.to_dict(verbose=False)
+    assert "trace" not in d
+
+
 def test_audit_headers():
     result = ConvertResult(
         markdown="x",

--- a/gateway/tests/unit/test_tracing.py
+++ b/gateway/tests/unit/test_tracing.py
@@ -1,0 +1,53 @@
+"""Unit tests for the tracing module."""
+from app.tracing import Trace
+
+
+def test_trace_creates_root_span():
+    t = Trace("request", mime_type="application/pdf")
+    t.finish()
+    d = t.to_dict()
+    assert d["name"] == "request"
+    assert d["attributes"]["mime_type"] == "application/pdf"
+    assert "duration_ms" in d
+
+
+def test_nested_spans():
+    t = Trace("request")
+    with t.span("docling") as docling_span:
+        with docling_span.span("http_request", payload_bytes=1000) as http_span:
+            http_span.set(status_code=200)
+    t.finish()
+    d = t.to_dict()
+    assert len(d["children"]) == 1
+    assert d["children"][0]["name"] == "docling"
+    http = d["children"][0]["children"][0]
+    assert http["name"] == "http_request"
+    assert http["attributes"]["payload_bytes"] == 1000
+    assert http["attributes"]["status_code"] == 200
+    assert "duration_ms" in http
+
+
+def test_span_set_merges_attributes():
+    t = Trace("request")
+    with t.span("step", a=1) as s:
+        s.set(b=2, c=3)
+    d = t.to_dict()
+    attrs = d["children"][0]["attributes"]
+    assert attrs == {"a": 1, "b": 2, "c": 3}
+
+
+def test_empty_children_omitted():
+    t = Trace("request")
+    t.finish()
+    d = t.to_dict()
+    assert "children" not in d
+
+
+def test_empty_attributes_omitted():
+    t = Trace("request")
+    with t.span("bare"):
+        pass
+    t.finish()
+    d = t.to_dict()
+    child = d["children"][0]
+    assert "attributes" not in child


### PR DESCRIPTION
When `?verbose=true` we show how long we spent in each function, and the input/output sizes of the various external calls